### PR TITLE
Add roster export and display on team pages

### DIFF
--- a/exportTeamData.py
+++ b/exportTeamData.py
@@ -2,6 +2,7 @@ import pandas as pd
 import os
 from ffLuckModel import calculateLuckScore
 from ffStandMatchData import getMatchups, currentWeek
+from espn_api.football import League
 import json
 
 # Load all weekly matchups
@@ -78,3 +79,28 @@ with open("teams.json", "w") as f:
     json.dump(team_names, f, indent=2)
 
 print("✅ teams.json created successfully.")
+
+# Create a roster JSON for all teams using the ESPN API
+league = League(
+    league_id=42024189,
+    year=2024,
+    espn_s2='AECycM1RSKC9H6KO4Qw7b0ZKIaa417A48498axeqW12XB0VFyWXroqy%2BFzAdJFMJUqxu4t05etxquUZYQ92C7V8N%2BzGT48zFtm4IJM04CG%2FG7zrSRXMBsqrw219pF4k7L0BYwwHr1om5AQNTKViQ5YJhH9SFEmGo03L1NTeuQSPy3Ws6HpQs2pfnZKuddHWxNUwH9HVOxVkOc4nSbCn8LPm2c1lsCAuuH26Z4laiqV2e0MCjMNizTi%2FS8VFHmVCXcPVejE3reh1JRyiHuKp1gE14',
+    swid='{CDA2BA80-43BE-41FB-9AB1-C8BE52DD4C45}'
+)
+
+rosters = {}
+for team in league.teams:
+    clean_team_name = ' '.join(team.team_name.strip().split())
+    roster_list = []
+    for player in team.roster:
+        roster_list.append({
+            "name": player.name,
+            "position": player.position,
+            "lineupSlot": player.lineupSlot
+        })
+    rosters[clean_team_name] = roster_list
+
+with open("rosters.json", "w") as f:
+    json.dump(rosters, f, indent=2)
+
+print("✅ rosters.json created successfully.")

--- a/rosters.json
+++ b/rosters.json
@@ -1,0 +1,346 @@
+{
+  "Game of Throws": [
+    {
+      "name": "Bijan Robinson",
+      "position": "N/A"
+    },
+    {
+      "name": "Bucky Irving",
+      "position": "N/A"
+    },
+    {
+      "name": "Cooper Kupp",
+      "position": "N/A"
+    },
+    {
+      "name": "DeVonta Smith",
+      "position": "N/A"
+    },
+    {
+      "name": "Jalen Hurts",
+      "position": "N/A"
+    },
+    {
+      "name": "Mike Evans",
+      "position": "N/A"
+    },
+    {
+      "name": "Rashee Rice",
+      "position": "N/A"
+    },
+    {
+      "name": "Taysom Hill",
+      "position": "N/A"
+    }
+  ],
+  "How I Metcalf Your Mother": [
+    {
+      "name": "A.J. Brown",
+      "position": "N/A"
+    },
+    {
+      "name": "DJ Moore",
+      "position": "N/A"
+    },
+    {
+      "name": "Jared Goff",
+      "position": "N/A"
+    },
+    {
+      "name": "Javonte Williams",
+      "position": "N/A"
+    },
+    {
+      "name": "Jonathan Taylor",
+      "position": "N/A"
+    },
+    {
+      "name": "Kareem Hunt",
+      "position": "N/A"
+    },
+    {
+      "name": "Kyle Pitts",
+      "position": "N/A"
+    },
+    {
+      "name": "Najee Harris",
+      "position": "N/A"
+    },
+    {
+      "name": "Nico Collins",
+      "position": "N/A"
+    },
+    {
+      "name": "Patrick Mahomes",
+      "position": "N/A"
+    },
+    {
+      "name": "Rico Dowdle",
+      "position": "N/A"
+    }
+  ],
+  "Hamilton Administration": [
+    {
+      "name": "Cade Otton",
+      "position": "N/A"
+    },
+    {
+      "name": "Chuba Hubbard",
+      "position": "N/A"
+    },
+    {
+      "name": "Drake London",
+      "position": "N/A"
+    },
+    {
+      "name": "Jordan Addison",
+      "position": "N/A"
+    },
+    {
+      "name": "Josh Allen",
+      "position": "N/A"
+    },
+    {
+      "name": "Malik Nabers",
+      "position": "N/A"
+    },
+    {
+      "name": "Zay Flowers",
+      "position": "N/A"
+    }
+  ],
+  "First and Ted": [
+    {
+      "name": "Brian Thomas Jr.",
+      "position": "N/A"
+    },
+    {
+      "name": "De'Von Achane",
+      "position": "N/A"
+    },
+    {
+      "name": "James Conner",
+      "position": "N/A"
+    },
+    {
+      "name": "Jayden Daniels",
+      "position": "N/A"
+    },
+    {
+      "name": "Justin Jefferson",
+      "position": "N/A"
+    },
+    {
+      "name": "Kyren Williams",
+      "position": "N/A"
+    },
+    {
+      "name": "Tank Bigsby",
+      "position": "N/A"
+    }
+  ],
+  "To infinity and Bijan": [
+    {
+      "name": "CeeDee Lamb",
+      "position": "N/A"
+    },
+    {
+      "name": "Dallas Goedert",
+      "position": "N/A"
+    },
+    {
+      "name": "David Montgomery",
+      "position": "N/A"
+    },
+    {
+      "name": "J.K. Dobbins",
+      "position": "N/A"
+    },
+    {
+      "name": "Jerry Jeudy",
+      "position": "N/A"
+    },
+    {
+      "name": "Lamar Jackson",
+      "position": "N/A"
+    },
+    {
+      "name": "Marvin Harrison Jr.",
+      "position": "N/A"
+    },
+    {
+      "name": "Zach Charbonnet",
+      "position": "N/A"
+    }
+  ],
+  "The Left Tacklers": [
+    {
+      "name": "Alvin Kamara",
+      "position": "N/A"
+    },
+    {
+      "name": "Amon-Ra St. Brown",
+      "position": "N/A"
+    },
+    {
+      "name": "Brock Purdy",
+      "position": "N/A"
+    },
+    {
+      "name": "Jauan Jennings",
+      "position": "N/A"
+    },
+    {
+      "name": "Jaxon Smith-Njigba",
+      "position": "N/A"
+    },
+    {
+      "name": "Joe Burrow",
+      "position": "N/A"
+    },
+    {
+      "name": "Rashid Shaheed",
+      "position": "N/A"
+    },
+    {
+      "name": "Trey McBride",
+      "position": "N/A"
+    }
+  ],
+  "Jared's Pack Attack": [
+    {
+      "name": "Aaron Jones",
+      "position": "N/A"
+    },
+    {
+      "name": "Breece Hall",
+      "position": "N/A"
+    },
+    {
+      "name": "Brock Bowers",
+      "position": "N/A"
+    },
+    {
+      "name": "Calvin Ridley",
+      "position": "N/A"
+    },
+    {
+      "name": "DK Metcalf",
+      "position": "N/A"
+    },
+    {
+      "name": "Jordan Love",
+      "position": "N/A"
+    },
+    {
+      "name": "Puka Nacua",
+      "position": "N/A"
+    },
+    {
+      "name": "Tony Pollard",
+      "position": "N/A"
+    },
+    {
+      "name": "Vikings D/ST",
+      "position": "N/A"
+    }
+  ],
+  "Team Kareem Pie \ud83e\udd67": [
+    {
+      "name": "Baker Mayfield",
+      "position": "N/A"
+    },
+    {
+      "name": "David Njoku",
+      "position": "N/A"
+    },
+    {
+      "name": "Derrick Henry",
+      "position": "N/A"
+    },
+    {
+      "name": "Ja'Marr Chase",
+      "position": "N/A"
+    },
+    {
+      "name": "Joe Mixon",
+      "position": "N/A"
+    },
+    {
+      "name": "Keenan Allen",
+      "position": "N/A"
+    }
+  ],
+  "Amon a Mission": [
+    {
+      "name": "Chris Godwin",
+      "position": "N/A"
+    },
+    {
+      "name": "Garrett Wilson",
+      "position": "N/A"
+    },
+    {
+      "name": "Jordan Mason",
+      "position": "N/A"
+    },
+    {
+      "name": "Rachaad White",
+      "position": "N/A"
+    },
+    {
+      "name": "Saquon Barkley",
+      "position": "N/A"
+    },
+    {
+      "name": "Terry McLaurin",
+      "position": "N/A"
+    }
+  ],
+  "Hawaii McLovins VIII": [
+    {
+      "name": "Bills D/ST",
+      "position": "N/A"
+    },
+    {
+      "name": "Bo Nix",
+      "position": "N/A"
+    },
+    {
+      "name": "Chris Olave",
+      "position": "N/A"
+    },
+    {
+      "name": "D'Andre Swift",
+      "position": "N/A"
+    },
+    {
+      "name": "George Kittle",
+      "position": "N/A"
+    },
+    {
+      "name": "Jahmyr Gibbs",
+      "position": "N/A"
+    },
+    {
+      "name": "Jalen Hurts",
+      "position": "N/A"
+    },
+    {
+      "name": "Josh Jacobs",
+      "position": "N/A"
+    },
+    {
+      "name": "Ladd McConkey",
+      "position": "N/A"
+    },
+    {
+      "name": "Travis Kelce",
+      "position": "N/A"
+    },
+    {
+      "name": "Tyreek Hill",
+      "position": "N/A"
+    }
+  ]
+}

--- a/teams.html
+++ b/teams.html
@@ -249,6 +249,11 @@
       <div id="win-loss-chart"></div>
     </div>
 
+    <div class="section" id="roster-section">
+      <h2>Roster</h2>
+      <ul id="roster-list"></ul>
+    </div>
+
     <div class="section" id="matchup-history">
     <h2>Matchup History</h2>
     <table id="matchup-table" style="width: 100%; border-collapse: collapse;">
@@ -274,6 +279,7 @@
     const teamSelect = document.getElementById("team-select");
     const teamNameHeading = document.getElementById("team-name");
     let standingsData = [];
+    let rosterData = {};
     function updateWinLossChart(data) {
       const weeks = [];
       let wins = 0;
@@ -352,33 +358,51 @@
         document.getElementById("pf-value").textContent = pf.toFixed(2);
         document.getElementById("pa-value").textContent = pa.toFixed(2);
 
-        }
+      }
 
-      } 
+    }
 
-          async function loadTeams() {
-          try {
-            const res = await fetch("teams.json");
-            const teams = await res.json();
+    function updateRoster(teamName) {
+      const rosterList = document.getElementById("roster-list");
+      rosterList.innerHTML = "";
+      const roster = rosterData[teamName];
+      if (roster && roster.length > 0) {
+        roster.forEach(player => {
+          const li = document.createElement("li");
+          li.textContent = `${player.position} - ${player.name}`;
+          rosterList.appendChild(li);
+        });
+      } else {
+        const li = document.createElement("li");
+        li.textContent = "No roster data available.";
+        rosterList.appendChild(li);
+      }
+    }
 
-            teams.forEach(team => {
-              const option = document.createElement("option");
-              option.value = team.replace(/\s+/g, "_");
-              option.text = team;
-              teamSelect.appendChild(option);
-            });
+    async function loadTeams() {
+      try {
+        const res = await fetch("teams.json");
+        const teams = await res.json();
 
-            const urlParams = new URLSearchParams(window.location.search);
-            const defaultTeam = urlParams.get("team") || teamSelect.options[0].value;
-            teamSelect.value = defaultTeam;
+        teams.forEach(team => {
+          const option = document.createElement("option");
+          option.value = team.replace(/\s+/g, "_");
+          option.text = team;
+          teamSelect.appendChild(option);
+        });
 
-            const standingsRes = await fetch("standings.json");
-            standingsData = await standingsRes.json();
-            updateBars(defaultTeam.replace(/_/g, " "));
+        const urlParams = new URLSearchParams(window.location.search);
+        const defaultTeam = urlParams.get("team") || teamSelect.options[0].value;
+        teamSelect.value = defaultTeam;
 
-            loadTeam(defaultTeam, teams);
-      
-          }catch (err) {
+        const standingsRes = await fetch("standings.json");
+        standingsData = await standingsRes.json();
+        const rosterRes = await fetch("rosters.json");
+        rosterData = await rosterRes.json();
+
+        updateBars(defaultTeam.replace(/_/g, " "));
+        loadTeam(defaultTeam, teams);
+      } catch (err) {
         document.getElementById('chart').innerHTML = "<p>Error loading team list</p>";
         console.error(err);
       }
@@ -390,6 +414,7 @@
       }
       const displayName = normalize(teams.find(t => t.replace(/\s+/g, "_") === teamSlug)) || teamSlug.replace(/_/g, " ");
       teamNameHeading.textContent = displayName;
+      updateRoster(displayName);
 
       try {
         const res = await fetch(`team_data/${teamSlug}.json`);


### PR DESCRIPTION
## Summary
- generate `rosters.json` for every team
- show each team's roster between the win/loss timeline and matchup history

## Testing
- `python exportTeamData.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas espn_api` *(fails: Could not find a version that satisfies the requirement pandas)*

------